### PR TITLE
Fix permission flow and redirect on app launch (Issue #307)

### DIFF
--- a/frontend/src/screens/CameraPermissionScreen.tsx
+++ b/frontend/src/screens/CameraPermissionScreen.tsx
@@ -1,6 +1,6 @@
 import { LinearGradient } from "expo-linear-gradient";
 import { useCameraPermissions } from "expo-camera";
-import React, { useEffect } from "react";
+import React from "react";
 import { Alert, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -12,19 +12,14 @@ const styles = CameraPermissionStyle;
 const CameraPermissionScreen = ({
   navigation,
 }: ScreenProps<"CameraPermissionScreen">) => {
-  const [permission, requestPermission] = useCameraPermissions();
-
-  useEffect(() => {
-    if (permission?.granted) {
-      navigation.replace("LocationPermissionScreen");
-    }
-  }, [navigation, permission]);
+  const [, requestPermission] = useCameraPermissions();
 
   const handleAllow = async () => {
     const response = await requestPermission();
 
     if (response?.granted) {
-      navigation.replace("LocationPermissionScreen");
+      // 🔁 Always return to Splash for centralized decision
+      navigation.replace("SplashScreen");
       return;
     }
 
@@ -37,7 +32,8 @@ const CameraPermissionScreen = ({
   };
 
   const handleSkip = () => {
-    navigation.replace("LocationPermissionScreen");
+    // 🔁 Even on skip, Splash decides what happens next
+    navigation.replace("SplashScreen");
   };
 
   return (
@@ -75,7 +71,9 @@ const CameraPermissionScreen = ({
               end={{ x: 1, y: 1 }}
               style={styles.primaryButton}
             >
-              <Text style={styles.primaryButtonText}>Allow Camera Access</Text>
+              <Text style={styles.primaryButtonText}>
+                Allow Camera Access
+              </Text>
             </LinearGradient>
           </TouchableOpacity>
 

--- a/frontend/src/screens/LocationPermissionScreen.tsx
+++ b/frontend/src/screens/LocationPermissionScreen.tsx
@@ -1,6 +1,5 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { useFocusEffect } from "@react-navigation/native";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import {
   Alert,
   Image,
@@ -40,23 +39,6 @@ const LocationPermissionScreen = ({
 }: ScreenProps<"LocationPermissionScreen">) => {
   const [requesting, setRequesting] = useState(false);
 
-  const goHomeIfGranted = useCallback(async () => {
-    const current = await Location.getForegroundPermissionsAsync();
-
-    if (current.status === "granted") {
-      navigation.replace("HomeScreen");
-      return true;
-    }
-
-    return false;
-  }, [navigation]);
-
-  useFocusEffect(
-    useCallback(() => {
-      goHomeIfGranted();
-    }, [goHomeIfGranted])
-  );
-
   const handleAllow = async () => {
     if (requesting) return;
 
@@ -65,7 +47,8 @@ const LocationPermissionScreen = ({
       const response = await Location.requestForegroundPermissionsAsync();
 
       if (response.status === "granted") {
-        navigation.replace("HomeScreen");
+        // 🔁 Return control to SplashScreen
+        navigation.replace("SplashScreen");
         return;
       }
 
@@ -80,7 +63,10 @@ const LocationPermissionScreen = ({
     }
   };
 
-  const handleSkip = () => navigation.replace("HomeScreen");
+  const handleSkip = () => {
+    // 🔁 SplashScreen decides next step
+    navigation.replace("SplashScreen");
+  };
 
   return (
     <LinearGradient


### PR DESCRIPTION
Issue: #307 

This PR fixes the permission flow by centralizing camera and location permission checks in the SplashScreen and making permission screens UI-only.

The app now redirects correctly to SignInScreen / HomeScreen only after both permissions are granted.

A short testing video is attached.

https://github.com/user-attachments/assets/e782150b-52f4-4bdf-b0d6-6bd164adb5ff


Note: While testing with Expo Go, camera permission may appear before the SplashScreen since Expo Go itself requires camera access for QR scanning. This does not affect production builds.