### PR TITLE
Reduce Camera capture time

### DIFF
--- a/frontend/src/screens/CameraScreen.tsx
+++ b/frontend/src/screens/CameraScreen.tsx
@@ -95,6 +95,15 @@ export default function CameraScreen({
     const permissionStatus = await ensureLocationPermission();
 
     if (permissionStatus === "granted") {
+      const servicesEnabled = await Location.hasServicesEnabledAsync();
+      if (!servicesEnabled) {
+        Alert.alert(
+          "Location off",
+          "Enable location services to add location data."
+        );
+        return;
+      }
+
       try {
         const location = await Location.getCurrentPositionAsync({
           accuracy: Location.Accuracy.Balanced,
@@ -105,7 +114,7 @@ export default function CameraScreen({
           location,
         });
       } catch (err) {
-        Alert.alert(err);
+        Alert.alert("Location error", "Unable to fetch your location.");
       }
     }
   };


### PR DESCRIPTION
Issue: #353 

Camera Screen took 2-5 sec to go to UploadConfirmationScreen,

skipped unnecessary preprocessing of image for loading UploadConfirmationScreen instantly