### PR TITLE
Bug: SignIn Screen - MapIcon

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import { View, ActivityIndicator } from "react-native";
+import { useFonts } from "expo-font";
+import { Ionicons } from "@expo/vector-icons";
 import { ClerkProvider } from "@clerk/clerk-expo";
 import Navigation from "./navigation/Navigation";
 import { ProfileProvider } from "./context/ProfileContext";
@@ -6,6 +9,25 @@ import { ProfileProvider } from "./context/ProfileContext";
 const CLERK_PUBLISHABLE_KEY = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
 export default function App() {
+  const [fontsLoaded] = useFonts({
+    ...Ionicons.font,
+  });
+
+  if (!fontsLoaded) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "#FFF5F5",
+        }}
+      >
+        <ActivityIndicator size="large" color="#f43f5e" />
+      </View>
+    );
+  }
+
   return (
     <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
       <ProfileProvider>


### PR DESCRIPTION
Issue: #353 
when the signin screen loads, sometimes it takes time to load the map icon and it looks absurd with just a plain colour box

![WhatsApp Image 2026-01-29 at 2 02 59 PM](https://github.com/user-attachments/assets/bf6b3b1c-93c2-40f1-91f0-7401949d89d1)


I have preloaded the Ionicons font globally in App.tsx to load fonts and icons first